### PR TITLE
move to using datastore in prod account and dont upload to dev accoun…

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -43,29 +43,6 @@ jobs:
 
     - name: Build dataset
       run: make
-
-    - name: Configure Dev AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{secrets.AWS_S3_ACCESS_KEY_ID}}
-        aws-secret-access-key: ${{secrets.AWS_S3_SECRET_ACCESS_KEY}}
-        aws-region: eu-west-2
-
-    - name: Save datasets to Dev S3
-      run: make save-dataset
-    
-    - name: Configure Temporary Production AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{secrets.TEMPORARY_PROD_AWS_ACCESS_KEY_ID}}
-        aws-secret-access-key: ${{secrets.TEMPORARY_PROD_AWS_ACCESS_SECRET}}
-        aws-region: eu-west-2
-    
-    - name: Save datasets to Temporary Prod S3
-      env:
-        COLLECTION_DATASET_BUCKET_NAME: ${{secrets.TEMPORARY_DATA_S3_BUCKET}}
-        HOISTED_COLLECTION_DATASET_BUCKET_NAME: ${{secrets.TEMPORARY_DATA_S3_BUCKET}}
-      run: make save-dataset
     
     - name: Configure Production AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/bin/download.sh
+++ b/bin/download.sh
@@ -2,7 +2,7 @@
 
 #set -e
 
-s3="https://digital-land-production-collection-dataset.s3.eu-west-2.amazonaws.com/"
+s3="https://files.planning.data.gov.uk/"
 
 dir=var/dataset/
 mkdir -p $dir


### PR DESCRIPTION
…t or temporary environment

Specifically only push to prod but also to ready data from the production bucket cdn rather than the old production bucket in the old dev account